### PR TITLE
Adds .only()

### DIFF
--- a/src/PublitApiRequest.spec.ts
+++ b/src/PublitApiRequest.spec.ts
@@ -461,6 +461,57 @@ describe('Request', () => {
     })
   })
 
+  describe('only()', () => {
+    it('should add only query parameter', async () => {
+      fetch.mockResponse(JSON.stringify({ id: '123321' }))
+
+      const request = await new PublitApiRequest<Thing>('things')
+        .only('id')
+        .show('123321')
+
+      expect(request).toMatchObject({ id: '123321' })
+      expect(fetch).toHaveBeenLastCalledWith(
+        'https://api.publit.com/publishing/v2.0/things/123321?only=id',
+        expect.objectContaining({
+          method: 'GET',
+        })
+      )
+    })
+
+    it('should add multiple only query parameters in separate calls', async () => {
+      fetch.mockResponse(JSON.stringify({ id: '123321' }))
+
+      const request = await new PublitApiRequest<Thing>('things')
+        .only('id')
+        .only('status')
+        .show('123321')
+
+      expect(request).toMatchObject({ id: '123321' })
+      expect(fetch).toHaveBeenLastCalledWith(
+        'https://api.publit.com/publishing/v2.0/things/123321?only=id%2Cstatus',
+        expect.objectContaining({
+          method: 'GET',
+        })
+      )
+    })
+
+    it('should add multiple only query parameters in one call', async () => {
+      fetch.mockResponse(JSON.stringify({ id: '123321' }))
+
+      const request = await new PublitApiRequest<Thing>('things')
+        .only('id', 'status')
+        .show('123321')
+
+      expect(request).toMatchObject({ id: '123321' })
+      expect(fetch).toHaveBeenLastCalledWith(
+        'https://api.publit.com/publishing/v2.0/things/123321?only=id%2Cstatus',
+        expect.objectContaining({
+          method: 'GET',
+        })
+      )
+    })
+  })
+
   it('should allow changing RequestInit before fetching', async () => {
     fetch.mockResponse('{}')
 

--- a/src/PublitApiRequest.ts
+++ b/src/PublitApiRequest.ts
@@ -341,6 +341,17 @@ export default class PublitApiRequest<T> {
     return this
   }
 
+  /**
+   * Specify a subset of attributes to return in the response
+   *
+   * ```ts
+   * request.only('name', 'description')
+   * ```
+   */
+  only(...attributes: (keyof T)[]): PublitApiRequest<T> {
+    return this.appendParam('only', attributes.join(','))
+  }
+
   setPayload(payload: FormData | Record<string, unknown>) {
     if (payload instanceof FormData) {
       this.requestInit.body = payload


### PR DESCRIPTION
Adds support for specifying which attributes should be returned in the response, e.g.

```ts
request.only('name', 'description')
```

Closes https://github.com/publitsweden/api-request/issues/5